### PR TITLE
Add a host header to OCSP requests

### DIFF
--- a/certvalidator/_urllib.py
+++ b/certvalidator/_urllib.py
@@ -1,0 +1,44 @@
+# coding: utf-8
+"""
+Various abstractions to cater for Python2/3 differences.
+"""
+from __future__ import unicode_literals, division, absolute_import, print_function
+import sys
+
+
+def _add_header(request, name, value):
+    """
+    Adds a header to a urllib2/urllib.request Request object, ensuring values
+    are encoded appropriately based on the version of Python
+
+    :param request:
+        An instance of urllib2.Request or urllib.request.Request
+
+    :param name:
+        A unicode string of the header name
+
+    :param value:
+        A unicode string of the header value
+    """
+
+    if sys.version_info < (3,):
+        name = name.encode('iso-8859-1')
+        value = value.encode('iso-8859-1')
+
+    request.add_header(name, value)
+
+
+def _get_host(request):
+    """
+    Get's the hostname from the request object according to the python version.
+
+    :param request:
+        An instance of urllib2.Request or urllib.request.Request
+
+    :returns:
+        A string containing the hostname without colon and portnumber.
+    """
+
+    if sys.version_info < (3,):
+        return request.get_host().split(":")[0]
+    return request.host.split(":")[0]

--- a/certvalidator/crl_client.py
+++ b/certvalidator/crl_client.py
@@ -7,6 +7,7 @@ from asn1crypto import crl, x509, cms, pem, util
 
 from ._types import str_cls, type_name
 from .version import __version__
+from ._urllib import _get_host, _add_header
 
 if sys.version_info < (3,):
     from urllib2 import Request, urlopen
@@ -81,8 +82,9 @@ def _grab_crl(user_agent, url, timeout):
     if sys.version_info < (3,):
         url = util.iri_to_uri(url)
     request = Request(url)
-    request.add_header(b'Accept', b'application/pkix-crl')
-    request.add_header(b'User-Agent', user_agent.encode('iso-8859-1'))
+    _add_header(request, 'Accept', 'application/pkix-crl')
+    _add_header(request, 'User-Agent', user_agent)
+    _add_header(request, 'Host', _get_host(request))
     response = urlopen(request, None, timeout)
     data = response.read()
     if pem.detect(data):
@@ -125,8 +127,9 @@ def fetch_certs(certificate_list, user_agent=None, timeout=10):
         if sys.version_info < (3,):
             url = util.iri_to_uri(url)
         request = Request(url)
-        request.add_header(b'Accept', b'application/pkix-cert,application/pkcs7-mime')
-        request.add_header(b'User-Agent', user_agent.encode('iso-8859-1'))
+        _add_header(request, 'Accept', 'application/pkix-cert,application/pkcs7-mime')
+        _add_header(request, 'User-Agent', user_agent)
+        _add_header(request, 'Host', _get_host(request))
         response = urlopen(request, None, timeout)
 
         content_type = response.headers['Content-Type'].strip()

--- a/certvalidator/crl_client.py
+++ b/certvalidator/crl_client.py
@@ -1,19 +1,11 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
-import sys
-
-from asn1crypto import crl, x509, cms, pem, util
+from asn1crypto import crl, x509, cms, pem
 
 from ._types import str_cls, type_name
 from .version import __version__
-from ._urllib import _get_host, _add_header
-
-if sys.version_info < (3,):
-    from urllib2 import Request, urlopen
-
-else:
-    from urllib.request import Request, urlopen
+from ._urllib import Request, urlopen
 
 
 def fetch(cert, use_deltas=True, user_agent=None, timeout=10):
@@ -78,13 +70,10 @@ def _grab_crl(user_agent, url, timeout):
     :return:
         An asn1crypto.crl.CertificateList object
     """
-
-    if sys.version_info < (3,):
-        url = util.iri_to_uri(url)
     request = Request(url)
-    _add_header(request, 'Accept', 'application/pkix-crl')
-    _add_header(request, 'User-Agent', user_agent)
-    _add_header(request, 'Host', _get_host(request))
+    request.add_header('Accept', 'application/pkix-crl')
+    request.add_header('User-Agent', user_agent)
+    request.add_header('Host', request.get_host().split(':')[0])
     response = urlopen(request, None, timeout)
     data = response.read()
     if pem.detect(data):
@@ -124,12 +113,10 @@ def fetch_certs(certificate_list, user_agent=None, timeout=10):
         raise TypeError('user_agent must be a unicode string, not %s' % type_name(user_agent))
 
     for url in certificate_list.issuer_cert_urls:
-        if sys.version_info < (3,):
-            url = util.iri_to_uri(url)
         request = Request(url)
-        _add_header(request, 'Accept', 'application/pkix-cert,application/pkcs7-mime')
-        _add_header(request, 'User-Agent', user_agent)
-        _add_header(request, 'Host', _get_host(request))
+        request.add_header('Accept', 'application/pkix-cert,application/pkcs7-mime')
+        request.add_header('User-Agent', user_agent)
+        request.add_header('Host', request.get_host().split(':')[0])
         response = urlopen(request, None, timeout)
 
         content_type = response.headers['Content-Type'].strip()

--- a/certvalidator/ocsp_client.py
+++ b/certvalidator/ocsp_client.py
@@ -102,6 +102,7 @@ def fetch(cert, issuer, hash_algo='sha1', nonce=True, user_agent=None, timeout=1
             _add_header(request, 'Accept', 'application/ocsp-response')
             _add_header(request, 'Content-Type', 'application/ocsp-request')
             _add_header(request, 'User-Agent', user_agent)
+            _add_header(request, 'Host', _get_host(request))
             response = urlopen(request, ocsp_request.dump(), timeout)
             ocsp_response = ocsp.OCSPResponse.load(response.read())
             request_nonce = ocsp_request.nonce_value
@@ -138,3 +139,19 @@ def _add_header(request, name, value):
         value = value.encode('iso-8859-1')
 
     request.add_header(name, value)
+
+
+def _get_host(request):
+    """
+    Get's the hostname from the request object according to the python version.
+
+    :param request:
+        An instance of urllib2.Request or urllib.request.Request
+
+    :returns:
+        A string containing the hostname without colon and portnumber.
+    """
+
+    if sys.version_info < (3,):
+        return request.get_host().split(":")[0]
+    return request.host.split(":")[0]

--- a/certvalidator/ocsp_client.py
+++ b/certvalidator/ocsp_client.py
@@ -9,10 +9,10 @@ from asn1crypto import core, ocsp, x509, algos, util
 from . import errors
 from ._types import str_cls, type_name
 from .version import __version__
+from ._urllib import _get_host, _add_header
 
 if sys.version_info < (3,):
     from urllib2 import Request, urlopen, URLError
-
 else:
     from urllib.request import Request, urlopen
     from urllib.error import URLError
@@ -117,41 +117,3 @@ def fetch(cert, issuer, hash_algo='sha1', nonce=True, user_agent=None, timeout=1
             last_e = e
 
     raise last_e
-
-
-def _add_header(request, name, value):
-    """
-    Adds a header to a urllib2/urllib.request Request object, ensuring values
-    are encoded appropriately based on the version of Python
-
-    :param request:
-        An instance of urllib2.Request or urllib.request.Request
-
-    :param name:
-        A unicode string of the header name
-
-    :param value:
-        A unicode string of the header value
-    """
-
-    if sys.version_info < (3,):
-        name = name.encode('iso-8859-1')
-        value = value.encode('iso-8859-1')
-
-    request.add_header(name, value)
-
-
-def _get_host(request):
-    """
-    Get's the hostname from the request object according to the python version.
-
-    :param request:
-        An instance of urllib2.Request or urllib.request.Request
-
-    :returns:
-        A string containing the hostname without colon and portnumber.
-    """
-
-    if sys.version_info < (3,):
-        return request.get_host().split(":")[0]
-    return request.host.split(":")[0]

--- a/certvalidator/ocsp_client.py
+++ b/certvalidator/ocsp_client.py
@@ -2,20 +2,13 @@
 from __future__ import unicode_literals, division, absolute_import, print_function
 
 import os
-import sys
 
-from asn1crypto import core, ocsp, x509, algos, util
+from asn1crypto import core, ocsp, x509, algos
 
 from . import errors
 from ._types import str_cls, type_name
 from .version import __version__
-from ._urllib import _get_host, _add_header
-
-if sys.version_info < (3,):
-    from urllib2 import Request, urlopen, URLError
-else:
-    from urllib.request import Request, urlopen
-    from urllib.error import URLError
+from ._urllib import Request, urlopen, URLError
 
 
 def fetch(cert, issuer, hash_algo='sha1', nonce=True, user_agent=None, timeout=10):
@@ -96,13 +89,11 @@ def fetch(cert, issuer, hash_algo='sha1', nonce=True, user_agent=None, timeout=1
     last_e = None
     for ocsp_url in cert.ocsp_urls:
         try:
-            if sys.version_info < (3,):
-                ocsp_url = util.iri_to_uri(ocsp_url)
             request = Request(ocsp_url)
-            _add_header(request, 'Accept', 'application/ocsp-response')
-            _add_header(request, 'Content-Type', 'application/ocsp-request')
-            _add_header(request, 'User-Agent', user_agent)
-            _add_header(request, 'Host', _get_host(request))
+            request.add_header('Accept', 'application/ocsp-response')
+            request.add_header('Content-Type', 'application/ocsp-request')
+            request.add_header('User-Agent', user_agent)
+            request.add_header('Host', request.get_host().split(":")[0])
             response = urlopen(request, ocsp_request.dump(), timeout)
             ocsp_response = ocsp.OCSPResponse.load(response.read())
             request_nonce = ocsp_request.nonce_value


### PR DESCRIPTION
Add Host header for OCSP requests, required for some OCSP servers, e.g. Let's Encrypt.