### PR TITLE
RSASSA-PSS support

### DIFF
--- a/certvalidator/validate.py
+++ b/certvalidator/validate.py
@@ -319,6 +319,8 @@ def _validate_path(validation_context, path, end_entity_name_override=None):
             verify_func = asymmetric.dsa_verify
         elif signature_algo == 'ecdsa':
             verify_func = asymmetric.ecdsa_verify
+        elif signature_algo == 'rsassa_pss':
+            verify_func = asymmetric.rsa_pss_verify
         else:
             raise PathValidationError(pretty_message(
                 '''


### PR DESCRIPTION
Currently, certvalidator only supports RSASS-PKCS1 v1.5. As described in [RFC 3447](https://tools.ietf.org/html/rfc3447#page-27), RSASSA-PSS (PKCS1 v2.1) is recommended over v.1.5. Many recently issued certificates use it already.

**This commit adds support for RSASSA-PSS signature validation.**