### PR TITLE
Ship readme.md/changelog.md in sdists (MANIFEST.in) so sdists build from source

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include readme.md
+include changelog.md


### PR DESCRIPTION
Two related notes: (1) the bug that breaks the RELEASED sdist on PyPI (setup.py importing the package, pulling asn1crypto) is already fixed on this branch's base — a release would fix source installs of the published version; (2) however, HEAD currently has a NEW sdist bug: setup.py reads readme.md, and nothing ships it in sdists, so an sdist cut from HEAD today cannot be installed either. This PR adds the two-line MANIFEST.in fixing that, so the next release's sdist works out of the box.

Verified: with this change, `python -m build` (sdist → wheel built from that sdist) succeeds in a clean python:3.12 container; without it, it fails. Found while build-checking popular PyPI packages for source-install breakage ([wheelproof](https://github.com/sethc555/wheelproof)).